### PR TITLE
Add compatibility with Nova 2.1.0

### DIFF
--- a/src/Froala.php
+++ b/src/Froala.php
@@ -169,11 +169,9 @@ class Froala extends Trix
         }
     }
 
-    public function showOnIndex()
+    public function showOnIndex($callback = true)
     {
-        $this->showOnIndex = true;
-
-        return $this;
+        return parent::showOnIndex(true);
     }
 
     /**


### PR DESCRIPTION
Nova 2.1.0 added `showOnIndex($callback)` on `Laravel\Nova\Fields\FieldElement` 

This PR add the compatibility with it to avoid the following error 

```
Declaration of Froala\NovaFroalaField\Froala::showOnIndex() should be compatible with Laravel\Nova\Fields\FieldElement::showOnIndex($callback = true)
```
