### PR TITLE
Fixes compatibility issue with Nova 2.1.0

### DIFF
--- a/src/Froala.php
+++ b/src/Froala.php
@@ -169,13 +169,6 @@ class Froala extends Trix
         }
     }
 
-    public function showOnIndex()
-    {
-        $this->showOnIndex = true;
-
-        return $this;
-    }
-
     /**
      * Specify the callback that should be used to get attached images list.
      *


### PR DESCRIPTION
Nova 2.1.0 added the ability to pass a Closure to field visibility methods.
As a result, Froala field now throws this error:

> Declaration of Froala\NovaFroalaField\Froala::showOnIndex() should be compatible with Laravel\Nova\Fields\FieldElement::showOnIndex($callback = true)

This PR fixes it by removing the function altogether.