### PR TITLE
$path = '/' in Froala

### DIFF
--- a/src/Froala.php
+++ b/src/Froala.php
@@ -103,7 +103,7 @@ class Froala extends Trix
     /**
      * Specify that file uploads should not be allowed.
      */
-    public function withFiles($disk = null)
+    public function withFiles($disk = null, $path = '/')
     {
         $this->withFiles = true;
 


### PR DESCRIPTION
Because Trix is updated in Nova after 2.5, this Froala isn't working anymore. This seems to fix the issue. 