### PR TITLE
added ability to register custom buttons (issue 29)

### DIFF
--- a/resources/js/components/FormField.vue
+++ b/resources/js/components/FormField.vue
@@ -33,9 +33,14 @@ export default {
             });
         }
 
-        new PluginsLoader(this.options, this.$toasted).registerPlugins().then((data) => {
+        const pluginLoader = new PluginsLoader(this.options, this.$toasted);
+
+        Promise.all([
+            pluginLoader.registerCustomButtons(),
+            pluginLoader.registerPlugins()
+        ]).then((data) => {
             this.loading = false;
-        })
+        });
     },
 
     data() {


### PR DESCRIPTION
This PR adds ability to register custom buttons, as discussed in [issue 29](https://github.com/froala/nova-froala-field/issues/29)

This is a quite tricky problem to solve, and this implementation is not that great. Using eval always feels dirty, and having to make the js file publicly available and fetching it with ajax also feels kinda gross, butt hopefully it will get the ball rolling and at least we have a starting point.

To register custom buttons. create a js file containing a function that receives a froala editor instance as its first parameter and make it publicly available on the server.

example:

```javascript
// /public/js/alert.js
(FroalaEditor) => {
    FroalaEditor.DefineIcon('alert', { NAME: 'info', SVG_KEY: 'help' });
    FroalaEditor.RegisterCommand('alert', {
        title: 'Hello',
        focus: false,
        undo: false,
        refreshAfterCallback: false,
        callback: function() {
            alert('Hello!');
        }
    });
}
```

Then, in your froala config file, add the following: 

```php
'customToolbarButtons' => [
    'alert' => '/js/alert.js',
],
```

That's all.

What do you think?