### PR TITLE
Fix `withFiles($disk, $path)` not writing to $path

### DIFF
--- a/src/Froala.php
+++ b/src/Froala.php
@@ -116,7 +116,7 @@ class Froala extends Trix
         if (config('nova.froala-field.attachments_driver', self::DRIVER_NAME) !== self::DRIVER_NAME) {
             $this->images(new AttachedImagesList($this));
 
-            return parent::withFiles($disk);
+            return parent::withFiles($disk, $path);
         }
 
         $this->attach(new StorePendingAttachment($this))

--- a/src/Froala.php
+++ b/src/Froala.php
@@ -189,6 +189,16 @@ class Froala extends Trix
     }
 
     /**
+     * Get the path that the field is stored at on disk.
+     *
+     * @return string|null
+     */
+    public function getStorageDir()
+    {
+        return $this->storagePath ?? '/';
+    }
+
+    /**
      * Get the full path that the field is stored at on disk.
      *
      * @return string|null

--- a/src/Handlers/StorePendingAttachment.php
+++ b/src/Handlers/StorePendingAttachment.php
@@ -43,10 +43,10 @@ class StorePendingAttachment
             'draft_id' => $request->draftId,
             'attachment' => config('nova.froala-field.preserve_file_names')
                 ? $request->attachment->storeAs(
-                    '/',
+                    $this->field->getStorageDir(),
                     $request->attachment->getClientOriginalName(),
                     $this->field->disk
-                ) : $request->attachment->store('/', $this->field->disk),
+                ) : $request->attachment->store($this->field->getStorageDir(), $this->field->disk),
             'disk' => $this->field->disk,
         ])->attachment;
 
@@ -57,9 +57,11 @@ class StorePendingAttachment
 
     protected function abortIfFileNameExists(Request $request): void
     {
+        $path = rtrim($this->field->getStorageDir(), '/') . '/' . $request->attachment->getClientOriginalName();
+
         if (config('nova.froala-field.preserve_file_names')
             && Storage::disk($this->field->disk)
-                ->exists($request->attachment->getClientOriginalName())
+                ->exists($path)
         ) {
             abort(response()->json([
                 'status' => Response::HTTP_CONFLICT,

--- a/src/Handlers/StorePendingAttachment.php
+++ b/src/Handlers/StorePendingAttachment.php
@@ -57,7 +57,7 @@ class StorePendingAttachment
 
     protected function abortIfFileNameExists(Request $request): void
     {
-        $path = rtrim($this->field->getStorageDir(), '/') . '/' . $request->attachment->getClientOriginalName();
+        $path = rtrim($this->field->getStorageDir(), '/').'/'.$request->attachment->getClientOriginalName();
 
         if (config('nova.froala-field.preserve_file_names')
             && Storage::disk($this->field->disk)

--- a/tests/Fixtures/TestResource.php
+++ b/tests/Fixtures/TestResource.php
@@ -21,7 +21,7 @@ class TestResource extends Resource
     {
         return [
             Text::make('Title'),
-            Froala::make('Content')->withFiles(TestCase::DISK),
+            Froala::make('Content')->withFiles(TestCase::DISK, TestCase::PATH),
         ];
     }
 }

--- a/tests/FroalaImageManagerControllerTest.php
+++ b/tests/FroalaImageManagerControllerTest.php
@@ -16,7 +16,7 @@ class FroalaImageManagerControllerTest extends TestCase
         for ($i = 0; $i <= 10; $i++) {
             $this->uploadPendingFile();
 
-            $url = Storage::disk(TestCase::DISK)->url($this->file->hashName());
+            $url = Storage::disk(TestCase::DISK)->url($this->getAttachmentLocation());
 
             $images[] = [
                 'url' => $url,
@@ -47,6 +47,6 @@ class FroalaImageManagerControllerTest extends TestCase
             'field' => 'content',
         ]);
 
-        Storage::disk(static::DISK)->assertMissing($this->file->hashName());
+        Storage::disk(static::DISK)->assertMissing($this->getAttachmentLocation());
     }
 }

--- a/tests/FroalaUploadControllerTest.php
+++ b/tests/FroalaUploadControllerTest.php
@@ -17,16 +17,16 @@ class FroalaUploadControllerTest extends TestCase
     {
         $response = $this->uploadPendingFile();
 
-        $response->assertJson(['link' => Storage::disk(static::DISK)->url($this->file->hashName())]);
+        $response->assertJson(['link' => Storage::disk(static::DISK)->url($this->getAttachmentLocation())]);
 
         $this->assertDatabaseHas((new PendingAttachment)->getTable(), [
             'draft_id' => $this->draftId,
             'disk' => static::DISK,
-            'attachment' => $this->file->hashName(),
+            'attachment' => $this->getAttachmentLocation(),
         ]);
 
         // Assert the file was stored...
-        Storage::disk(static::DISK)->assertExists($this->file->hashName());
+        Storage::disk(static::DISK)->assertExists($this->getAttachmentLocation());
 
         // Assert a file does not exist...
         Storage::disk(static::DISK)->assertMissing('missing.jpg');
@@ -55,8 +55,8 @@ class FroalaUploadControllerTest extends TestCase
 
         $this->assertDatabaseHas((new Attachment)->getTable(), [
             'disk' => static::DISK,
-            'attachment' => $this->file->hashName(),
-            'url' => Storage::disk(static::DISK)->url($this->file->hashName()),
+            'attachment' => $this->getAttachmentLocation(),
+            'url' => Storage::disk(static::DISK)->url($this->getAttachmentLocation()),
             'attachable_id' => $response->json('id'),
             'attachable_type' => Article::class,
         ]);
@@ -69,13 +69,13 @@ class FroalaUploadControllerTest extends TestCase
 
         $this->storeArticle();
 
-        Storage::disk(static::DISK)->assertExists($this->file->hashName());
+        Storage::disk(static::DISK)->assertExists($this->getAttachmentLocation());
 
         $this->json('DELETE', 'nova-vendor/froala-field/articles/attachments/content', [
             'src' => $src,
         ]);
 
-        Storage::disk(static::DISK)->assertMissing($this->file->hashName());
+        Storage::disk(static::DISK)->assertMissing($this->getAttachmentLocation());
     }
 
     /** @test */
@@ -86,7 +86,7 @@ class FroalaUploadControllerTest extends TestCase
         for ($i = 0; $i <= 3; $i++) {
             $this->uploadPendingFile();
 
-            $fileNames[] = $this->file->hashName();
+            $fileNames[] = $this->getAttachmentLocation();
 
             $this->regenerateUpload();
         }
@@ -110,7 +110,7 @@ class FroalaUploadControllerTest extends TestCase
         for ($i = 0; $i <= 5; $i++) {
             $this->uploadPendingFile();
 
-            $fileNames[] = $this->file->hashName();
+            $fileNames[] = $this->getAttachmentLocation();
 
             $this->regenerateUpload();
         }

--- a/tests/PreserveFilenamesTest.php
+++ b/tests/PreserveFilenamesTest.php
@@ -24,16 +24,16 @@ class PreserveFilenamesTest extends TestCase
     {
         $response = $this->uploadPendingFile();
 
-        $response->assertJson(['link' => Storage::disk(static::DISK)->url($this->file->getClientOriginalName())]);
+        $response->assertJson(['link' => Storage::disk(static::DISK)->url($this->getAttachmentLocation(true))]);
 
         $this->assertDatabaseHas((new PendingAttachment)->getTable(), [
             'draft_id' => $this->draftId,
             'disk' => static::DISK,
-            'attachment' => $this->file->getClientOriginalName(),
+            'attachment' => $this->getAttachmentLocation(true),
         ]);
 
         // Assert the file was stored...
-        Storage::disk(static::DISK)->assertExists($this->file->getClientOriginalName());
+        Storage::disk(static::DISK)->assertExists($this->getAttachmentLocation(true));
     }
 
     /** @test */

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -17,6 +17,8 @@ abstract class TestCase extends OrchestraTestCase
 {
     const DISK = 'public';
 
+    const PATH = 'subpath';
+
     public static $user;
 
     public function setUp(): void

--- a/tests/TrixDriverUploadTest.php
+++ b/tests/TrixDriverUploadTest.php
@@ -38,16 +38,16 @@ class TrixDriverUploadTest extends TestCase
     {
         $response = $this->uploadPendingFile();
 
-        $response->assertJson(['link' => Storage::disk(static::DISK)->url($this->file->hashName())]);
+        $response->assertJson(['link' => Storage::disk(static::DISK)->url($this->getAttachmentLocation())]);
 
         $this->assertDatabaseHas((new PendingAttachment)->getTable(), [
             'draft_id' => $this->draftId,
             'disk' => static::DISK,
-            'attachment' => $this->file->hashName(),
+            'attachment' => $this->getAttachmentLocation(),
         ]);
 
         // Assert the file was stored...
-        Storage::disk(static::DISK)->assertExists($this->file->hashName());
+        Storage::disk(static::DISK)->assertExists($this->getAttachmentLocation());
 
         // Assert a file does not exist...
         Storage::disk(static::DISK)->assertMissing('missing.jpg');
@@ -76,8 +76,8 @@ class TrixDriverUploadTest extends TestCase
 
         $this->assertDatabaseHas((new Attachment)->getTable(), [
             'disk' => static::DISK,
-            'attachment' => $this->file->hashName(),
-            'url' => Storage::disk(static::DISK)->url($this->file->hashName()),
+            'attachment' => $this->getAttachmentLocation(),
+            'url' => Storage::disk(static::DISK)->url($this->getAttachmentLocation()),
             'attachable_id' => $response->json('id'),
             'attachable_type' => Article::class,
         ]);
@@ -90,13 +90,13 @@ class TrixDriverUploadTest extends TestCase
 
         $this->storeArticle();
 
-        Storage::disk(static::DISK)->assertExists($this->file->hashName());
+        Storage::disk(static::DISK)->assertExists($this->getAttachmentLocation());
 
         $this->json('DELETE', 'nova-api/articles/trix-attachment/content', [
             'attachmentUrl' => $src,
         ]);
 
-        Storage::disk(static::DISK)->assertMissing($this->file->hashName());
+        Storage::disk(static::DISK)->assertMissing($this->getAttachmentLocation());
     }
 
     /** @test */
@@ -107,7 +107,7 @@ class TrixDriverUploadTest extends TestCase
         for ($i = 0; $i <= 3; $i++) {
             $this->uploadPendingFile();
 
-            $fileNames[] = $this->file->hashName();
+            $fileNames[] = $this->getAttachmentLocation();
 
             $this->regenerateUpload();
         }
@@ -131,7 +131,7 @@ class TrixDriverUploadTest extends TestCase
         for ($i = 0; $i <= 5; $i++) {
             $this->uploadPendingFile();
 
-            $fileNames[] = $this->file->hashName();
+            $fileNames[] = $this->getAttachmentLocation();
 
             $this->regenerateUpload();
         }

--- a/tests/UploadsHelper.php
+++ b/tests/UploadsHelper.php
@@ -2,12 +2,11 @@
 
 namespace Froala\NovaFroalaField\Tests;
 
+use function Froala\NovaFroalaField\nova_version_at_least;
 use Illuminate\Foundation\Testing\TestResponse;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
-
-use function Froala\NovaFroalaField\nova_version_at_least;
 
 trait UploadsHelper
 {
@@ -56,6 +55,6 @@ trait UploadsHelper
     {
         $filename = $preserveFilename ? $this->file->getClientOriginalName() : $this->file->hashName();
 
-        return nova_version_at_least('2.7.0') ? rtrim(TestCase::PATH, '/') . '/' . $filename : $filename;
+        return nova_version_at_least('2.7.0') ? rtrim(TestCase::PATH, '/').'/'.$filename : $filename;
     }
 }

--- a/tests/UploadsHelper.php
+++ b/tests/UploadsHelper.php
@@ -7,6 +7,8 @@ use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 
+use function Froala\NovaFroalaField\nova_version_at_least;
+
 trait UploadsHelper
 {
     protected $file;
@@ -48,5 +50,12 @@ trait UploadsHelper
             'content' => 'Some content',
             'contentDraftId' => $this->draftId,
         ]);
+    }
+
+    protected function getAttachmentLocation($preserveFilename = false): string
+    {
+        $filename = $preserveFilename ? $this->file->getClientOriginalName() : $this->file->hashName();
+
+        return nova_version_at_least('2.7.0') ? rtrim(TestCase::PATH, '/') . '/' . $filename : $filename;
     }
 }


### PR DESCRIPTION
Fixes files not being stored in the proper $path when given as an argument to the `withFiles()` method. I refactored the testing to include a helper function for getting the file path more easily.

Closes #51 