### PR TITLE
Detect uploaded images with mimetype

### DIFF
--- a/src/Handlers/AttachedImagesList.php
+++ b/src/Handlers/AttachedImagesList.php
@@ -5,6 +5,7 @@ namespace Froala\NovaFroalaField\Handlers;
 use Froala\NovaFroalaField\Froala;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 
 class AttachedImagesList
 {
@@ -33,14 +34,14 @@ class AttachedImagesList
     {
         $images = [];
 
-        $Storage = Storage::disk($this->field->disk);
+        $disk = Storage::disk($this->field->disk);
 
-        foreach ($Storage->allFiles() as $file) {
-            if (! app()->runningUnitTests() and ! @getimagesize($Storage->url($file))) {
+        foreach ($disk->allFiles() as $file) {
+            if (! app()->runningUnitTests() && Str::before((string) $disk->getMimetype($file), '/') !== 'image') {
                 continue;
             }
 
-            $url = $Storage->url($file);
+            $url = $disk->url($file);
             $images[] = [
                 'url' => $url,
                 'thumb' => $url,


### PR DESCRIPTION
Hello,
When `allow_url_fopen` is disabled, `FroalaImageManagerController` controller timeouts on  `getimagesize` because it's called with an URL.
This way is maybe less bullet proof, but it should work everytime.
Thanks for your package,
Best
