### PR TITLE
Make attachment model classes dynamic

### DIFF
--- a/config/froala-field.php
+++ b/config/froala-field.php
@@ -42,6 +42,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Attachment Models
+    |--------------------------------------------------------------------------
+    |
+    | If you want to extend the attachment models, you can replace
+    | the default classes with your own custom ones here.
+    |
+    */
+    'attachment_model'         => Froala\NovaFroalaField\Models\Attachment::class,
+    'pending_attachment_model' => Froala\NovaFroalaField\Models\PendingAttachment::class,
+
+    /*
+    |--------------------------------------------------------------------------
     | Editor Attachments Driver
     |--------------------------------------------------------------------------
     |

--- a/config/froala-field.php
+++ b/config/froala-field.php
@@ -49,7 +49,7 @@ return [
     | the default classes with your own custom ones here.
     |
     */
-    'attachment_model'         => Froala\NovaFroalaField\Models\Attachment::class,
+    'attachment_model' => Froala\NovaFroalaField\Models\Attachment::class,
     'pending_attachment_model' => Froala\NovaFroalaField\Models\PendingAttachment::class,
 
     /*

--- a/src/Handlers/DeleteAttachments.php
+++ b/src/Handlers/DeleteAttachments.php
@@ -2,7 +2,6 @@
 
 namespace Froala\NovaFroalaField\Handlers;
 
-use Froala\NovaFroalaField\Models\Attachment;
 use Illuminate\Http\Request;
 
 class DeleteAttachments
@@ -15,14 +14,24 @@ class DeleteAttachments
     public $field;
 
     /**
+     * The attachment model class name.
+     *
+     * @var string
+     * @psalm-var class-string<\Froala\NovaFroalaField\Models\Attachment>
+     */
+    protected $attachmentModelClassName;
+
+    /**
      * Create a new class instance.
      *
      * @param  \Froala\NovaFroalaField\Froala  $field
+     * @param  string $attachmentModelClassName
      * @return void
      */
-    public function __construct($field)
+    public function __construct($field, $attachmentModelClassName)
     {
         $this->field = $field;
+        $this->attachmentModelClassName = $attachmentModelClassName;
     }
 
     /**
@@ -34,7 +43,7 @@ class DeleteAttachments
      */
     public function __invoke(Request $request, $model)
     {
-        Attachment::where('attachable_type', get_class($model))
+        $this->attachmentModelClassName::where('attachable_type', get_class($model))
                 ->where('attachable_id', $model->getKey())
                 ->get()
                 ->each

--- a/src/Handlers/DeleteAttachments.php
+++ b/src/Handlers/DeleteAttachments.php
@@ -17,7 +17,6 @@ class DeleteAttachments
      * The attachment model class name.
      *
      * @var string
-     * @psalm-var class-string<\Froala\NovaFroalaField\Models\Attachment>
      */
     protected $attachmentModelClassName;
 

--- a/src/Handlers/DetachAttachment.php
+++ b/src/Handlers/DetachAttachment.php
@@ -2,11 +2,29 @@
 
 namespace Froala\NovaFroalaField\Handlers;
 
-use Froala\NovaFroalaField\Models\Attachment;
 use Illuminate\Http\Request;
 
 class DetachAttachment
 {
+    /**
+     * The attachment model class name.
+     *
+     * @var string
+     * @psalm-var class-string<\Froala\NovaFroalaField\Models\Attachment>
+     */
+    protected $attachmentModelClassName;
+
+    /**
+     * Create a new class instance.
+     *
+     * @param  string $attachmentModelClassName
+     * @return void
+     */
+    public function __construct($attachmentModelClassName)
+    {
+        $this->attachmentModelClassName = $attachmentModelClassName;
+    }
+
     /**
      * Delete an attachment from the field.
      *
@@ -15,7 +33,7 @@ class DetachAttachment
      */
     public function __invoke(Request $request)
     {
-        Attachment::where('url', $request->src)
+        $this->attachmentModelClassName::where('url', $request->src)
                         ->get()
                         ->each
                         ->purge();

--- a/src/Handlers/DetachAttachment.php
+++ b/src/Handlers/DetachAttachment.php
@@ -10,7 +10,6 @@ class DetachAttachment
      * The attachment model class name.
      *
      * @var string
-     * @psalm-var class-string<\Froala\NovaFroalaField\Models\Attachment>
      */
     protected $attachmentModelClassName;
 

--- a/src/Handlers/DiscardPendingAttachments.php
+++ b/src/Handlers/DiscardPendingAttachments.php
@@ -10,7 +10,6 @@ class DiscardPendingAttachments
      * The pending attachment model class name.
      *
      * @var string
-     * @psalm-var class-string<\Froala\NovaFroalaField\Models\PendingAttachment>
      */
     protected $pendingAttachmentModelClassName;
 

--- a/src/Handlers/DiscardPendingAttachments.php
+++ b/src/Handlers/DiscardPendingAttachments.php
@@ -2,11 +2,29 @@
 
 namespace Froala\NovaFroalaField\Handlers;
 
-use Froala\NovaFroalaField\Models\PendingAttachment;
 use Illuminate\Http\Request;
 
 class DiscardPendingAttachments
 {
+    /**
+     * The pending attachment model class name.
+     *
+     * @var string
+     * @psalm-var class-string<\Froala\NovaFroalaField\Models\PendingAttachment>
+     */
+    protected $pendingAttachmentModelClassName;
+
+    /**
+     * Create a new class instance.
+     *
+     * @param  string $pendingAttachmentModelClassName
+     * @return void
+     */
+    public function __construct($pendingAttachmentModelClassName)
+    {
+        $this->pendingAttachmentModelClassName = $pendingAttachmentModelClassName;
+    }
+
     /**
      * Discard pendings attachments on the field.
      *
@@ -15,7 +33,7 @@ class DiscardPendingAttachments
      */
     public function __invoke(Request $request)
     {
-        PendingAttachment::where('draft_id', $request->draftId)
+        $this->pendingAttachmentModelClassName::where('draft_id', $request->draftId)
                     ->get()
                     ->each
                     ->purge();

--- a/src/Handlers/StorePendingAttachment.php
+++ b/src/Handlers/StorePendingAttachment.php
@@ -3,7 +3,6 @@
 namespace Froala\NovaFroalaField\Handlers;
 
 use Froala\NovaFroalaField\Froala;
-use Froala\NovaFroalaField\Models\PendingAttachment;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Storage;
@@ -19,14 +18,24 @@ class StorePendingAttachment
     public $field;
 
     /**
+     * The pending attachment model class name.
+     *
+     * @var string
+     * @psalm-var class-string<\Froala\NovaFroalaField\Models\PendingAttachment>
+     */
+    protected $pendingAttachmentModelClassName;
+
+    /**
      * Create a new invokable instance.
      *
      * @param  \Froala\NovaFroalaField\Froala  $field
+     * @param  string $pendingAttachmentModelClassName
      * @return void
      */
-    public function __construct(Froala $field)
+    public function __construct(Froala $field, $pendingAttachmentModelClassName)
     {
         $this->field = $field;
+        $this->pendingAttachmentModelClassName = $pendingAttachmentModelClassName;
     }
 
     /**
@@ -39,7 +48,7 @@ class StorePendingAttachment
     {
         $this->abortIfFileNameExists($request);
 
-        $attachment = PendingAttachment::create([
+        $attachment = $this->pendingAttachmentModelClassName::create([
             'draft_id' => $request->draftId,
             'attachment' => config('nova.froala-field.preserve_file_names')
                 ? $request->attachment->storeAs(

--- a/src/Handlers/StorePendingAttachment.php
+++ b/src/Handlers/StorePendingAttachment.php
@@ -21,7 +21,6 @@ class StorePendingAttachment
      * The pending attachment model class name.
      *
      * @var string
-     * @psalm-var class-string<\Froala\NovaFroalaField\Models\PendingAttachment>
      */
     protected $pendingAttachmentModelClassName;
 

--- a/src/Jobs/PruneStaleAttachments.php
+++ b/src/Jobs/PruneStaleAttachments.php
@@ -2,8 +2,6 @@
 
 namespace Froala\NovaFroalaField\Jobs;
 
-use Froala\NovaFroalaField\Models\PendingAttachment;
-
 class PruneStaleAttachments
 {
     /**
@@ -13,7 +11,10 @@ class PruneStaleAttachments
      */
     public function __invoke()
     {
-        PendingAttachment::where('created_at', '<=', now()->subDays(1))
+        /** @psalm-var class-string<\Froala\NovaFroalaField\Models\PendingAttachment> $pendingAttachmentModelClassName */
+        $pendingAttachmentModelClassName = config('nova.froala-field.pending_attachment_model');
+
+        $pendingAttachmentModelClassName::where('created_at', '<=', now()->subDays(1))
                     ->orderBy('id', 'desc')
                     ->chunk(100, function ($attachments) {
                         $attachments->each->purge();

--- a/src/Jobs/PruneStaleAttachments.php
+++ b/src/Jobs/PruneStaleAttachments.php
@@ -11,7 +11,6 @@ class PruneStaleAttachments
      */
     public function __invoke()
     {
-        /** @psalm-var class-string<\Froala\NovaFroalaField\Models\PendingAttachment> $pendingAttachmentModelClassName */
         $pendingAttachmentModelClassName = config('nova.froala-field.pending_attachment_model');
 
         $pendingAttachmentModelClassName::where('created_at', '<=', now()->subDays(1))

--- a/src/Models/PendingAttachment.php
+++ b/src/Models/PendingAttachment.php
@@ -45,7 +45,6 @@ class PendingAttachment extends Model
      */
     public function persist(Froala $field, $model)
     {
-        /** @psalm-var class-string<\Froala\NovaFroalaField\Models\Attachment> $attachmentModelClassName */
         $attachmentModelClassName = config('nova.froala-field.attachment_model');
 
         $attachmentModelClassName::create([

--- a/src/Models/PendingAttachment.php
+++ b/src/Models/PendingAttachment.php
@@ -45,7 +45,10 @@ class PendingAttachment extends Model
      */
     public function persist(Froala $field, $model)
     {
-        Attachment::create([
+        /** @psalm-var class-string<\Froala\NovaFroalaField\Models\Attachment> $attachmentModelClassName */
+        $attachmentModelClassName = config('nova.froala-field.attachment_model');
+
+        $attachmentModelClassName::create([
             'attachable_type' => get_class($model),
             'attachable_id' => $model->getKey(),
             'attachment' => $this->attachment,

--- a/tests/FroalaUploadControllerTest.php
+++ b/tests/FroalaUploadControllerTest.php
@@ -2,8 +2,6 @@
 
 namespace Froala\NovaFroalaField\Tests;
 
-use Froala\NovaFroalaField\Models\Attachment;
-use Froala\NovaFroalaField\Models\PendingAttachment;
 use function Froala\NovaFroalaField\nova_version_at_least;
 use Froala\NovaFroalaField\Tests\Fixtures\Article;
 use Illuminate\Support\Facades\Storage;
@@ -19,7 +17,7 @@ class FroalaUploadControllerTest extends TestCase
 
         $response->assertJson(['link' => Storage::disk(static::DISK)->url($this->getAttachmentLocation())]);
 
-        $this->assertDatabaseHas((new PendingAttachment)->getTable(), [
+        $this->assertDatabaseHas($this->getPendingAttachmentsTable(), [
             'draft_id' => $this->draftId,
             'disk' => static::DISK,
             'attachment' => $this->getAttachmentLocation(),
@@ -53,7 +51,7 @@ class FroalaUploadControllerTest extends TestCase
             ]);
         }
 
-        $this->assertDatabaseHas((new Attachment)->getTable(), [
+        $this->assertDatabaseHas($this->getAttachmentsTable(), [
             'disk' => static::DISK,
             'attachment' => $this->getAttachmentLocation(),
             'url' => Storage::disk(static::DISK)->url($this->getAttachmentLocation()),

--- a/tests/PreserveFilenamesTest.php
+++ b/tests/PreserveFilenamesTest.php
@@ -2,7 +2,6 @@
 
 namespace Froala\NovaFroalaField\Tests;
 
-use Froala\NovaFroalaField\Models\PendingAttachment;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Storage;
 
@@ -26,7 +25,7 @@ class PreserveFilenamesTest extends TestCase
 
         $response->assertJson(['link' => Storage::disk(static::DISK)->url($this->getAttachmentLocation(true))]);
 
-        $this->assertDatabaseHas((new PendingAttachment)->getTable(), [
+        $this->assertDatabaseHas($this->getPendingAttachmentsTable(), [
             'draft_id' => $this->draftId,
             'disk' => static::DISK,
             'attachment' => $this->getAttachmentLocation(true),

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,6 +5,7 @@ namespace Froala\NovaFroalaField\Tests;
 use Froala\NovaFroalaField\FroalaFieldServiceProvider;
 use Froala\NovaFroalaField\Tests\Fixtures\TestResource;
 use Froala\NovaFroalaField\Tests\Fixtures\User;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Route;
 use Laravel\Nova\Nova;
@@ -94,5 +95,31 @@ abstract class TestCase extends OrchestraTestCase
             $table->string('email');
             $table->string('password');
         });
+    }
+
+    /**
+     * @return string
+     */
+    protected function getAttachmentsTable()
+    {
+        $modelClassName = $this->app['config']->get('nova.froala-field.attachment_model');
+
+        /** @var Model $model */
+        $model = new $modelClassName();
+
+        return $model->getTable();
+    }
+
+    /**
+     * @return string
+     */
+    protected function getPendingAttachmentsTable()
+    {
+        $modelClassName = $this->app['config']->get('nova.froala-field.pending_attachment_model');
+
+        /** @var Model $model */
+        $model = new $modelClassName();
+
+        return $model->getTable();
     }
 }


### PR DESCRIPTION
In my current project I work with UUID's for all my models. I want the Froala attachments to also use UUID's instead of integers. To do this I need to extend the models and set their `$keyType` property to `string`. This currently isn't possible so I've made the model classes dynamic so you can easily swap them with extensions.

```php
<?php

namespace App\Models\Froala;

use Froala\NovaFroalaField\Models\Attachment as OriginalAttachment;

class Attachment extends OriginalAttachment
{
    protected $keyType = 'string';
}
```

```php
// froala-field.php config
'attachment_model'  => App\Models\Froala\Attachment::class,
```