### PR TITLE
Use morph mapping for attachables

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -19,4 +19,9 @@
             <directory suffix=".php">src/</directory>
         </whitelist>
     </filter>
+    <php>
+        <env name="DB_CONNECTION" value="testing"/>
+        <env name="APP_KEY" value="base64:2fl+Ktvkfl+Fuz4Qp/A75G2RTiWVA/ZoKZvp6fiiM10="/>
+        <env name="APP_DEBUG" value="true"/>
+    </php>
 </phpunit>

--- a/src/Handlers/DeleteAttachments.php
+++ b/src/Handlers/DeleteAttachments.php
@@ -34,7 +34,7 @@ class DeleteAttachments
      */
     public function __invoke(Request $request, $model)
     {
-        Attachment::where('attachable_type', get_class($model))
+        Attachment::where('attachable_type', $model->getMorphClass())
                 ->where('attachable_id', $model->getKey())
                 ->get()
                 ->each

--- a/src/Models/PendingAttachment.php
+++ b/src/Models/PendingAttachment.php
@@ -46,7 +46,7 @@ class PendingAttachment extends Model
     public function persist(Froala $field, $model)
     {
         Attachment::create([
-            'attachable_type' => get_class($model),
+            'attachable_type' => $model->getMorphClass(),
             'attachable_id' => $model->getKey(),
             'attachment' => $this->attachment,
             'disk' => $field->disk,

--- a/tests/Fixtures/TestServiceProvider.php
+++ b/tests/Fixtures/TestServiceProvider.php
@@ -2,16 +2,15 @@
 
 namespace Froala\NovaFroalaField\Tests\Fixtures;
 
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\ServiceProvider;
 
 class TestServiceProvider extends ServiceProvider
 {
     public function boot()
     {
-    }
-
-    public function register()
-    {
-        $this->app['config']->set('nova.froala-field.attachments_driver', 'trix');
+        Relation::morphMap([
+            'article' => Article::class,
+        ]);
     }
 }

--- a/tests/FroalaUploadControllerTest.php
+++ b/tests/FroalaUploadControllerTest.php
@@ -5,7 +5,6 @@ namespace Froala\NovaFroalaField\Tests;
 use Froala\NovaFroalaField\Models\Attachment;
 use Froala\NovaFroalaField\Models\PendingAttachment;
 use function Froala\NovaFroalaField\nova_version_at_least;
-use Froala\NovaFroalaField\Tests\Fixtures\Article;
 use Illuminate\Support\Facades\Storage;
 
 class FroalaUploadControllerTest extends TestCase
@@ -58,7 +57,7 @@ class FroalaUploadControllerTest extends TestCase
             'attachment' => $this->getAttachmentLocation(),
             'url' => Storage::disk(static::DISK)->url($this->getAttachmentLocation()),
             'attachable_id' => $response->json('id'),
-            'attachable_type' => Article::class,
+            'attachable_type' => 'article',
         ]);
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -53,23 +53,6 @@ abstract class TestCase extends OrchestraTestCase
     }
 
     /**
-     * Define environment setup.
-     *
-     * @param  \Illuminate\Foundation\Application  $app
-     * @return void
-     */
-    protected function getEnvironmentSetUp($app)
-    {
-        // Setup default database to use sqlite :memory:
-        $app['config']->set('database.default', 'testbench');
-        $app['config']->set('database.connections.testbench', [
-            'driver' => 'sqlite',
-            'database' => ':memory:',
-            'prefix' => '',
-        ]);
-    }
-
-    /**
      * Set up the database.
      *
      * @param \Illuminate\Foundation\Application $app

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,7 @@ namespace Froala\NovaFroalaField\Tests;
 
 use Froala\NovaFroalaField\FroalaFieldServiceProvider;
 use Froala\NovaFroalaField\Tests\Fixtures\TestResource;
+use Froala\NovaFroalaField\Tests\Fixtures\TestServiceProvider;
 use Froala\NovaFroalaField\Tests\Fixtures\User;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Route;
@@ -49,6 +50,7 @@ abstract class TestCase extends OrchestraTestCase
             NovaServiceProvider::class,
             NovaApplicationServiceProvider::class,
             FroalaFieldServiceProvider::class,
+            TestServiceProvider::class,
         ];
     }
 

--- a/tests/TrixDriverUploadTest.php
+++ b/tests/TrixDriverUploadTest.php
@@ -2,9 +2,8 @@
 
 namespace Froala\NovaFroalaField\Tests;
 
-use function Froala\NovaFroalaField\nova_version_at_least;
 use Froala\NovaFroalaField\Tests\Fixtures\Article;
-use Froala\NovaFroalaField\Tests\Fixtures\TestServiceProvider;
+use function Froala\NovaFroalaField\nova_version_at_least;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\Storage;
 use Laravel\Nova\Trix\Attachment;
@@ -26,11 +25,9 @@ class TrixDriverUploadTest extends TestCase
 
     protected function getPackageProviders($app)
     {
-        $providers = parent::getPackageProviders($app);
+        $app['config']->set('nova.froala-field.attachments_driver', 'trix');
 
-        array_unshift($providers, TestServiceProvider::class);
-
-        return $providers;
+        return parent::getPackageProviders($app);
     }
 
     /** @test */

--- a/tests/TrixDriverUploadTest.php
+++ b/tests/TrixDriverUploadTest.php
@@ -2,8 +2,8 @@
 
 namespace Froala\NovaFroalaField\Tests;
 
-use Froala\NovaFroalaField\Tests\Fixtures\Article;
 use function Froala\NovaFroalaField\nova_version_at_least;
+use Froala\NovaFroalaField\Tests\Fixtures\Article;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\Storage;
 use Laravel\Nova\Trix\Attachment;

--- a/tests/UploadsHelper.php
+++ b/tests/UploadsHelper.php
@@ -32,7 +32,7 @@ trait UploadsHelper
 
     protected function uploadPendingFile(): TestResponse
     {
-        $url = config('nova.froala-field.attachments_driver') === 'trix'
+        $url = $this->app['config']->get('nova.froala-field.attachments_driver') === 'trix'
             ? '/nova-api/articles/trix-attachment/content'
             : 'nova-vendor/froala-field/articles/attachments/content';
 


### PR DESCRIPTION
I like to use morph mapping for all model references that are written to the database so that moving a model class won't break any data. See the [Laravel docs](https://laravel.com/docs/8.x/eloquent-relationships#custom-polymorphic-types).

~~This PR only implements morph mapping support for the Froala attachments. Trix still uses the FQN without any way to change that. I've opened a feature request issue for Nova:~~
https://github.com/laravel/nova-issues/issues/3376

**Update**
Nova has been updated to use morph mapping for Trix in [3.25.0](https://nova.laravel.com/releases/3.25.0).

> Nova will now use the getMorphClass method for Trix field attachments.