### PR TITLE
always persist pending attachments when using with spatie/nova-translatable

### DIFF
--- a/src/Froala.php
+++ b/src/Froala.php
@@ -141,21 +141,21 @@ class Froala extends Trix
     protected function fillAttribute(NovaRequest $request, $requestAttribute, $model, $attribute)
     {
         if (isset($this->fillCallback)) {
-            return call_user_func(
+            call_user_func(
                 $this->fillCallback,
                 $request,
                 $model,
                 $attribute,
                 $requestAttribute
             );
+        } else {
+            $this->fillAttributeFromRequest(
+                $request,
+                $requestAttribute,
+                $model,
+                $attribute
+            );
         }
-
-        $this->fillAttributeFromRequest(
-            $request,
-            $requestAttribute,
-            $model,
-            $attribute
-        );
 
         if ($request->{$this->attribute.'DraftId'} && $this->withFiles) {
             $pendingAttachmentClass =


### PR DESCRIPTION
**What I am trying to do**
I am trying to use this package with [spatie/nova-translatable](https://github.com/spatie/nova-translatable) package.
Something like this
```php
use Froala\NovaFroalaField\Froala;
use Spatie\NovaTranslatable\Translatable;

Translatable::make([
    Froala::make('Biography')->withFiles('public'),
]),
```

**The problems**
- **Problem 1**
When images are selected and sent to be stored as a pending attachment, `FroalaUploadController`'s `store` method return **404**. The problem lies with the [spatie/nova-translatable](https://github.com/spatie/nova-translatable) package for which I created a PR [**here**](https://github.com/spatie/nova-translatable/pull/68).
- **Problem 2**
This problem arises after the **Problem 1** is solved. Imagine we got around the **Problem 1** by overriding a base `Translatable` class as the following.
```php
<?PHP

namespace App\Nova\Fields;

use Illuminate\Contracts\Validation\Rule;
use Laravel\Nova\Fields\Field;
use Spatie\NovaTranslatable\Translatable as SpatieTranslatable;

class Translatable extends SpatieTranslatable
{

    protected function createTranslatedField(Field $originalField, string $locale): Field
    {
        $originalAttribute = $originalField->attribute;
        $translatedField = parent::createTranslatedField($originalField, $locale);
        $translatedField->attribute = 'translations_'.$originalAttribute.'_'.$locale;

        return $translatedField;
    }
}
```
When images are selected, the images are saved pending attachments. But when submitting the form, the pending attachments will not be persisted. This is because `Translatable`'s `createTranslatedField` method defines a `fillUsing` callback on every translatable field. And the `fillAttribute` on `Froala` will just check if there exists a fill callback and executes and returns that. (It will not persist the pending attachments there as expected).
So in this PR, what I did is to run a callback if it exists and then always persist the pending attachments in `fillAttribute`.

See this sample project's [nova-translatable-with-froala](https://github.com/xdiaoa/nova-translatable-trix-issue/tree/nova-translatable-with-froala) branch to quickly check the issues.

**Note**: This PR depends on the [spatie/nova-translatable PR](https://github.com/spatie/nova-translatable) to be merged.

Thanks :)